### PR TITLE
Fix BSD variants when parsing entry names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ __pycache__/
 
 /*.egg-info
 
-/test_data/
+**/test_data/
 /dist/
 /build/

--- a/ar/archive.py
+++ b/ar/archive.py
@@ -94,7 +94,7 @@ def load(stream):
         if name.startswith("#1/"):
             namesize = int(name.split('/')[-1].strip())
             name = stream.read(namesize).decode().split('\x00',1)[0]
-            stream.seek(-namesize, 1)
+            size -= namesize
 
         if name == '/':
             stream.seek(pad(size, 2), 1)

--- a/ar/archive.py
+++ b/ar/archive.py
@@ -91,6 +91,11 @@ def load(stream):
         name = name.decode().rstrip()
         size = int(size.decode().rstrip())
 
+        if name.startswith("#1/"):
+            namesize = int(name.split('/')[-1].strip())
+            name = stream.read(namesize).decode().split('\x00',1)[0]
+            stream.seek(-namesize, 1)
+
         if name == '/':
             stream.seek(pad(size, 2), 1)
         elif name == '//':

--- a/ar/tests/test_ar.py
+++ b/ar/tests/test_ar.py
@@ -31,7 +31,7 @@ def bad_archive():
 def test_list(simple_archive):
     with simple_archive.open('rb') as f:
         archive = Archive(f)
-        assert ['file0.txt', 'file1.bin'] == [entry.name for entry in archive]
+        assert ['file0.txt', 'file1.bin'] == [entry.name for entry in archive if entry.name != '__.SYMDEF SORTED']
 
 
 def test_read_content(simple_archive):


### PR DESCRIPTION
This PR try to support static library files (`.a`) on macOSX.

As written in wikipedia page:
> BSD variant
BSD ar stores filenames right-padded with ASCII spaces. This causes issues with spaces inside filenames. 4.4BSD ar stores extended filenames by placing the string "#1/" followed by the file name length in the file name field, and storing the real filename in front of the data section.[6]

Hence, the `#1/len` is detected and processed.

By using this PR's code, I locally save object files, and compare with `7zz x file.a`'s result, which is binary same.