### PR TITLE
mark Substream as seekable

### DIFF
--- a/ar/substream.py
+++ b/ar/substream.py
@@ -18,6 +18,9 @@ class Substream(io.RawIOBase):
         else:
             raise ValueError(f"Unexpected origin: {origin}")
 
+    def seekable(self):
+        return True
+
     def read(self, n=None):
         if n is None:
             n = self.size


### PR DESCRIPTION
Some libraries will refuse to even try to read from file objects if seekable returns False (which the default implementation on `io.RawIOBase` does)